### PR TITLE
Support ADM-style npz files

### DIFF
--- a/dgm_eval/dataloaders.py
+++ b/dgm_eval/dataloaders.py
@@ -45,6 +45,25 @@ class ImagePathDataset(torch.utils.data.Dataset):
             img = self.transform(img)
         return img
 
+class NpzDataset(torch.utils.data.Dataset):
+    """
+    Create a custom dataset from a npz file of images, as used in ADM's evaluation code.
+    See https://github.com/openai/guided-diffusion/tree/main/evaluations for more details.
+    """
+    def __init__(self, path, transform=None):
+        self.path = path
+        self.data = np.load(path)['arr_0']
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, i):
+        img = Image.fromarray(self.data[i]).convert('RGB')
+        if self.transform is not None:
+            img = self.transform(img)
+        return img
+
 class DataLoader():
     """
     Create Datasets and Dataloaders from ImagePathDataset and from torchvision.datasets.
@@ -85,10 +104,28 @@ class DataLoader():
         Get dataset from local path or from torchvision.datasets
         """
         if os.path.exists(self.path):
-            self.get_local_dataset()
+            if os.path.isfile(self.path) and self.path.endswith('.npz'):
+                self.get_local_adm_dataset()
+            else:
+                self.get_local_dataset()
 
         else:
             self.get_torchvision_dataset()
+
+    def get_local_adm_dataset(self):
+        """
+        Get dataset stored in ADM npz format (see https://github.com/openai/guided-diffusion/tree/main/evaluations) from disk
+        """
+
+        self.dataset_name = os.path.splitext(os.path.basename(os.path.normpath(self.path)))[0]
+
+        self.files = None
+        self.labels = None
+        # Confirm data at path is in proper format
+        try:
+            self.data_set = NpzDataset(self.path, transform=self.transform)
+        except:
+            raise RuntimeError(f'Images cannot be loaded from {self.path}. Expecting ADM-style npz file: {IMAGE_EXTENSIONS}')
 
     def get_local_dataset(self):
         """


### PR DESCRIPTION
The de facto evaluation pipeline for computing FID (on ImageNet, but also on other datasets) is the one from the OpenAI guided diffusion repo: https://github.com/openai/guided-diffusion/tree/main/evaluations. This one stores image batches as `.npz` files, where each file is just stacked uint8 images. This PR adds support for reading these npz image batches with dgm-eval. CLI/API-wise, you just pass a path to an npz file in place of a directory containing images.

Philosophy/why is this a useful addition: on large-scale clusters, writing thousands of small files is typically prohibited/not viable, so generation scripts will typically have to create sharded outputs anyways. Due to OpenAI's evaluation suite being well-established for the predecessor metrics that still are expected to be reported in new papers, many people already do this sharding using their format. The format is also maximally simple (just an npz file that contains the uncompressed images that is easily written and read with numpy). In the end, it also amounts to a minimal change to the current codebase and does not introduce any additional dependencies.